### PR TITLE
fix(release): pass secrets to org-release (App token for release-please)

### DIFF
--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -15,3 +15,4 @@ on:
 jobs:
   create-release:
     uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
+    secrets: inherit


### PR DESCRIPTION
One-line fix: the org-release caller lacked `secrets: inherit`, so post-merge release publishing ran on the read-only github.token and failed ('Resource not accessible by integration'). Org `RELEASE_APP_*` secrets exist org-wide; inheriting fixes publishing and enables the future auto_release_patch path. Fleet mini-pass (v0.11.3 wave follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S